### PR TITLE
fix: update Chicago Taxi Dataset URL to Zenodo

### DIFF
--- a/results/ak_tutorial.ipynb
+++ b/results/ak_tutorial.ipynb
@@ -10,7 +10,7 @@
     "import awkward as ak\n",
     "\n",
     "metadata = ak.metadata_from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\"\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\"\n",
     ")"
    ]
   },
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "taxi = ak.from_parquet(\n",
-    "    \"https://pivarski-princeton.s3.amazonaws.com/chicago-taxi.parquet\",\n",
+    "    \"https://zenodo.org/records/14537442/files/chicago-taxi.parquet\",\n",
     "    row_groups=[0],\n",
     "    columns=[\"trip.km\", \"trip.begin.l*\", \"trip.end.l*\", \"trip.path.*\"],\n",
     ")"


### PR DESCRIPTION
Since we use this dataset a lot, I created a [Zenodo page](https://doi.org/10.5281/zenodo.14537441) for it.

[![](https://zenodo.org/badge/DOI/10.5281/zenodo.14537442.svg)](https://doi.org/10.5281/zenodo.14537441)

I'll need to delete the copy on AWS, so please accept this PR to update all of your URL references. Thanks!